### PR TITLE
ignore the package.zip binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ $RECYCLE.BIN/
 Network Trash Folder
 Temporary Items
 .apdisk
+Package.zip


### PR DESCRIPTION
updates .gitignore so that the package.zip file is ignored. 
This is often compiled temporarily to upload into the Chrome Web Store on local machines but doesn't need to be tracked or uploaded.