### PR TITLE
Show age of employee on non-Permanent profiles #23

### DIFF
--- a/Package/js/ProfilePage.js
+++ b/Package/js/ProfilePage.js
@@ -32,12 +32,12 @@ if(currentPageURL == urlencode("https://" + currentDomain + "/damstra/skills.asp
 	
 		
 	// Date of Birth
-	dob = $('#header > table > tbody > tr > td:nth-child(1) > div > font:nth-child(6) > i').text();
+	dob = $('#header > table > tbody > tr > td:nth-child(1) > div > font > i').text();
 	var year=Number(dob.substr(6,4));
 	var month=Number(dob.substr(3,2))-1;
 	var day=Number(dob.substr(0,2));
 	var today=new Date();
 	var age=today.getFullYear()-year;
 	if(today.getMonth()<month || (today.getMonth()==month && today.getDate()<day)){age--;}
-	$('#header > table > tbody > tr > td:nth-child(1) > div > font:nth-child(6) > i').after("<span class='jlxAge'> ("+ age +" years old)</span>")
+	$('#header > table > tbody > tr > td:nth-child(1) > div > font > i').after("<span class='jlxAge'> ("+ age +" years old)</span>")
 }

--- a/Package/js/base.js
+++ b/Package/js/base.js
@@ -8,7 +8,7 @@
 
 function jlxVersioning() {
 	// this is the overall version of the TWMS-Mod (per the manifest)
-	return "v1.3.5";
+	return "v1.3.5.1";
 }
 
 var CurModAccentColor = "#ff51b1"

--- a/Package/manifest.json
+++ b/Package/manifest.json
@@ -1,7 +1,7 @@
 {
 	"manifest_version": 2,
 	"name": "WCPL-TWMS Mods",
-	"version": "1.3.5",
+	"version": "1.3.5.1",
 	 
 	"author": "jasonalex",
 	


### PR DESCRIPTION
squashes bug where the age function wasn't working on profiles of non-permanent employees due to the selector being too specific.